### PR TITLE
Fix long-history rendering and complete RC1 standalone builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "@types/react": "~18.3.1",
     "tsdown": "^0.22.2",
     "tsx": "^4.22.4",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "@deepseek-ai/dsh-session-turn-outline": "0.1.2-rc.1"
   },
   "dependencies": {
     "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "files": [
     "lib",
+    "skills",
     "src",
     "tests",
     "scripts",

--- a/scripts/link-harness-dependencies.mjs
+++ b/scripts/link-harness-dependencies.mjs
@@ -8,6 +8,8 @@ const local = resolve('node_modules');
 mkdirSync(local, { recursive: true });
 const shared = {
   '@deepseek-ai/cordis': 'vendor/cordis',
+  '@deepseek-ai/dsh-api-session-controller': 'packages/api/session-controller',
+  '@deepseek-ai/dsh-session-turn-outline': 'packages/session/session-turn-outline',
   '@deepseek-ai/dsh-client-store': 'packages/client/store',
   '@deepseek-ai/dsh-client-ui-chat': 'packages/client/ui-chat',
   '@deepseek-ai/dsh-client-ui-conversation': 'packages/client/ui-conversation',
@@ -20,6 +22,7 @@ const shared = {
   '@deepseek-ai/dsh-util-workspace-path': 'packages/util/workspace-path',
 };
 function link(name, target) {
+  if (!existsSync(target)) throw new Error(`Missing Harness dependency target: ${name} (${target})`);
   const destination = join(local, name);
   mkdirSync(dirname(destination), { recursive: true });
   if (existsSync(destination)) {

--- a/skills/generative-mcpapps/SKILL.md
+++ b/skills/generative-mcpapps/SKILL.md
@@ -1,100 +1,47 @@
 ---
 name: generative-mcpapps
-description: >-
-  Render interactive, dynamic HTML/JS components and widgets inside any AI harness
-  supporting the MCP Apps standard (SEP-1865 / io.modelcontextprotocol/ui), such as
-  DeepSeek Harness with dsh-better-display. Use this skill whenever presenting interactive
-  data visualizations, multi-variant double-blind evaluations, dynamic calculators, stateful
-  forms, configuration wizards, or rich controls that exceed plain Markdown capabilities.
+description: "Render interactive HTML/JS widgets, product UI mockups, and clickable prototypes inside the chat (MCP Apps / SEP-1865). Use whenever the user asks to see, preview, compare, or interact with a design (mockup, prototype, 画出来看看): data visualizations, calculators, stateful forms, config wizards, or any UI richer than plain Markdown."
 ---
 
 # Generative MCP Apps
 
-Guide for generating and delivering interactive HTML/JS user interfaces inside AI harnesses compliant with the Model Context Protocol Apps extension (**SEP-1865 / `io.modelcontextprotocol/ui`**).
+Create self-contained interactive HTML/JS widgets, UI mockups, and clickable prototypes in chat. This is an Agent Skill with YAML metadata and Markdown instructions; it has no Gemini-specific syntax or model requirement.
 
-Instead of relying on platform-exclusive proprietary tags, this skill produces self-contained, theme-adaptive web components that render inside standard sandboxed iframes (`sandbox="allow-scripts allow-forms"`) and communicate bidirectionally with the host agent via JSON-RPC `window.postMessage`.
+## Select the delivery surface
 
----
+- In DSH with Better Display enabled, emit an `mcp-app` fenced code block. The reading view renders it in an iframe with `sandbox="allow-scripts allow-forms"`.
+- In another harness, use only its available, documented UI tool and actual input schema. The Better Display fence and message aliases below are not a universal MCP Apps transport.
+- If no inline renderer is available, save a standalone HTML artifact and explain how to open it. Do not claim that a plain code block was rendered.
 
-## Information Hierarchy & Reference Pointers
+The harness must discover this skill before automatic selection can work. Keep the whole `generative-mcpapps/` folder together, including references and examples, in a skill directory supported by that harness. Merely placing it inside a plugin repository does not prove that the current agent has loaded it.
 
-- **Protocol & Communication**: Consult [references/sep1865_protocol.md](references/sep1865_protocol.md) for bidirectional JSON-RPC message schemas (`ui/initialize`, `ui/resize`, `ui/submit`, and event passing).
-- **Template & Theme Tokens**: Consult [references/html_boilerplate.md](references/html_boilerplate.md) for CSS theme variable mappings, Tailwind integration, and responsive card containers.
-- **Reference Implementation**: Inspect [examples/interactive_quiz.html](examples/interactive_quiz.html) for a complete working implementation featuring local state, reactive DOM updates, and host dispatch.
+## Build the widget
 
----
+1. Choose local interaction (tabs, filters, calculations) or an explicit submission back to chat. For Better Display, submission fills the composer; the user still sends the message. It does not execute tools or commands automatically.
+2. Inline critical CSS and JavaScript. Use semantic theme variables with readable fallbacks, a transparent body, and layouts that fit widths from 320px to 1200px. Avoid `100vh` and `min-h-screen`: Better Display measures content height and clamps it to 60–2400px.
+3. Read [HTML boilerplate and theme tokens](references/html_boilerplate.md) when assembling a card. Read [Better Display host messages](references/sep1865_protocol.md) only when using host communication. The latter documents this plugin's implementation, not a full MCP Apps specification.
+4. For a selectable local-state example, inspect [interactive_quiz.html](examples/interactive_quiz.html). Adapt its content and controls to the user's request.
 
-## Execution Workflow
+## Deliver in Better Display
 
-Execute these 4 sequential steps to produce and render an interactive component.
+Output the complete HTML document directly in the answer:
 
-### Step 1: Interface & Scope Assessment
+````markdown
+```mcp-app title="交互原型"
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>交互原型</title>
+</head>
+<body>
+  <!-- Include the widget's inline styles, content, and script here. -->
+</body>
+</html>
+```
+````
 
-Before generating code, determine the presentation boundary:
+## Verify the result
 
-1. **Height Budget**: Content height is automatically measured and adapted by the host runtime (from 60px to 2400px). Avoid setting `min-h-screen`, `100vh`, or fixed full-height containers on body.
-2. **Interaction Mode**:
-   - **Display-Only / Local Interactive**: Calculations, tab switching, and visual filtering that run purely client-side without modifying backend agent state.
-   - **Bidirectional Tool Dispatch**: Actions requiring the agent to perform follow-up work (submitting choices, parameter tuning, triggering commands).
-3. **Asset Self-Containment**: Assume strict Content Security Policy (CSP). Inline all critical CSS and JavaScript; avoid relying on unrestricted external third-party script CDNs unless explicitly permitted.
-
-### Step 2: Assemble the Self-Contained HTML Document
-
-Compose the HTML document following the structure in [references/html_boilerplate.md](references/html_boilerplate.md):
-
-1. **Root Transparency**: Set `<body style="background: transparent;">` so the widget container seamlessly inherits the host background.
-2. **Theme Adaptability**: Apply semantic CSS variables (`var(--card-bg, #ffffff)`, `var(--text-main, #0f172a)`, `var(--border-color, #e2e8f0)`) or Tailwind theme classes (`dark:`) with fallback values to ensure legibility across both dark and light modes.
-3. **Host Communication Hook**: Include the MCP Apps `postMessage` transport helper if the UI allows triggering host tools or dispatching state:
-   ```javascript
-   function sendToHost(method, params = {}) {
-     window.parent.postMessage({
-       jsonrpc: "2.0",
-       id: "req-" + Date.now(),
-       method: method,
-       params: params
-     }, "*");
-   }
-   ```
-
-### Step 3: Deliver via MCP Apps Channel
-
-Deliver the assembled HTML to the host through one of the available dynamic pathways:
-
-- **Path A (Markdown Code Block — Direct & Universal in dsh-better-display)**:
-  Directly output the HTML within a ````mcp-app` code fence. The reading view will automatically mount it inside an isolated, theme-aware sandbox:
-  ````markdown
-  ```mcp-app title="双盲方案盲选评测器"
-  <!DOCTYPE html>
-  <html lang="zh-CN">
-  <head>
-    <meta charset="UTF-8">
-    <title>双盲方案盲选评测器</title>
-  </head>
-  <body>
-    ...
-  </body>
-  </html>
-  ```
-  ````
-
-- **Path B (Dedicated Dynamic UI Tool)**:
-  If the harness provides an MCP tool for dynamic rendering (e.g., `render_ui`, `show_canvas`, or `create_view`):
-  Invoke the tool directly with the HTML string and metadata:
-  ```json
-  {
-    "tool": "render_ui",
-    "parameters": {
-      "title": "Interactive Benchmark Panel",
-      "html": "<!DOCTYPE html><html>...</html>"
-    }
-  }
-  ```
-
-### Step 4: Verification & Completion Criteria
-
-The generation task is complete when all of the following criteria are satisfied:
-
-1. **DOM Structure**: Document is complete with valid `<!DOCTYPE html>`, `<html>`, `<head>`, and `<body>` tags.
-2. **Theme Contrast**: All text elements use semantic theme variables or high-contrast fallback tokens; no hardcoded white-on-white or dark-on-dark text combinations.
-3. **Responsiveness**: The root container fits cleanly within variable host widths (320px to 1200px) without horizontal clipping.
-4. **Interactive Feedback**: Interactive options update reactive state, and the submit button dispatches a clean `ui/submit` or `ui/update-model-context` payload.
+Check the complete document, narrow-width layout, readable theme contrast, and the requested interaction. For a submission widget, verify that the chosen data reaches the chat composer; distinguish that from a sent message or completed agent action. A local-only widget needs no host submission. Report only the rendering and interaction actually observed in the available harness.

--- a/skills/generative-mcpapps/examples/interactive_quiz.html
+++ b/skills/generative-mcpapps/examples/interactive_quiz.html
@@ -133,10 +133,10 @@
     function submitChoice() {
       if (!currentSelection) return;
 
-      document.getElementById('status-text').innerText = "已提交给 Agent！";
+      document.getElementById('status-text').innerText = "已发送到聊天输入框，请确认并发送。";
       document.getElementById('submit-btn').disabled = true;
 
-      // 通过 SEP-1865 标准向 Host 提交结果
+      // 通过 Better Display 适配器将选择填入聊天输入框
       window.parent.postMessage({
         jsonrpc: "2.0",
         id: "eval-" + Date.now(),

--- a/skills/generative-mcpapps/references/sep1865_protocol.md
+++ b/skills/generative-mcpapps/references/sep1865_protocol.md
@@ -1,121 +1,54 @@
-# SEP-1865 JSON-RPC Communication Protocol
+# Better Display host messages
 
-This reference defines the bidirectional communication protocol between the sandboxed UI iframe and the host AI client under the **SEP-1865 (`io.modelcontextprotocol/ui`)** specification.
+This documents the adapter in `src/client/McpAppFrame.tsx`, not the full SEP-1865 specification. Use these messages for Better Display's `mcp-app` iframe. Other hosts require their own documented transport and capabilities.
 
----
+## Initialization and theme
 
-## 1. Handshake & Lifecycle
+The iframe can send `ui/initialize` with a JSON-RPC request ID. Better Display responds with `result.protocolVersion` and `result.hostContext`, including `theme`, `locale`, and `styles.variables`.
 
-When the host initializes the iframe containing the MCP App:
+For compatibility, Better Display also sends an initial `ui/initialize` notification with those theme fields in `params`. Later theme changes arrive as `ui/notifications/host-context-changed`. The plugin injects a theme and height helper into HTML documents.
 
-1. **Host Initialization (`ui/initialize`)**:
-   The host sends an initialization message containing configuration, initial state, and active theme tokens.
-
-   ```json
-   {
-     "jsonrpc": "2.0",
-     "method": "ui/initialize",
-     "params": {
-       "theme": "dark",
-       "locale": "zh-CN",
-       "context": {
-         "conversationId": "conv-12345",
-         "readOnly": false
-       }
-     }
-   }
-   ```
-
-2. **Iframe Readiness Notification (`ui/ready` or `ui/notifications/initialized`)**:
-   The iframe notifies the host that scripts have mounted and the DOM is ready to accept events.
-
-   ```json
-   {
-     "jsonrpc": "2.0",
-     "method": "ui/ready",
-     "params": {
-       "version": "1.0.0"
-     }
-   }
-   ```
-
-3. **Live Theme Change Notification (`ui/notifications/host-context-changed`)**:
-   When the host user switches light/dark mode, host broadcasts this event so the iframe updates its theme variables in real-time.
-
----
-
-## 2. Client-to-Host Invocations (Iframe -> Host)
-
-The iframe triggers actions in the host using `window.parent.postMessage`.
-
-### 2.1 Triggering an MCP Tool (`tools/call`)
-When a user clicks a button (e.g., "Run Regression Tests" or "Confirm Selection"):
+When handling parent messages, verify the source:
 
 ```javascript
-window.parent.postMessage({
-  jsonrpc: "2.0",
-  id: "req-001",
-  method: "tools/call",
-  params: {
-    name: "execute_benchmark",
-    arguments: {
-      suite: "all",
-      targetBranch: "main"
-    }
+window.addEventListener("message", (event) => {
+  if (event.source !== window.parent) return;
+  const msg = event.data;
+  if (!msg || msg.jsonrpc !== "2.0") return;
+  const context = msg.result?.hostContext || msg.params;
+  if (context?.theme) {
+    document.documentElement.dataset.theme = context.theme;
   }
-}, "*");
+});
 ```
 
-### 2.2 Submitting Form / State to Chat (`ui/submit` or `ui/update-model-context`)
-When the user submits a form or completes an interactive quiz:
+The sandbox has an opaque origin, so messages to the parent use `"*"`. The host checks that incoming messages originate from this iframe's content window.
+
+## Submit a choice to the composer
 
 ```javascript
 window.parent.postMessage({
   jsonrpc: "2.0",
-  id: "req-002",
+  id: "choice-" + Date.now(),
   method: "ui/submit",
-  params: {
-    task: "quiz_completed",
-    choice: "B",
-    desc: "延迟消息队列"
-  }
+  params: { task: "quiz_completed", choice: "B", desc: "Selected option B" }
 }, "*");
 ```
 
-### 2.3 Resizing Request (`ui/resize`)
-When dynamic content inside the card expands or contracts, request an iframe height adjustment (note: `dsh-better-display` also automatically auto-measures via ResizeObserver):
+The host displays a receipt and fills the chat composer with a prompt derived from the parameters. The user must send it. `ui/update-model-context` is handled as the same composer action in this adapter; do not assume a silent model-context update. These submit handlers do not send a JSON-RPC success response, so do not wait indefinitely for one.
+
+There is no `tools/call` handler in this adapter. Use submission for a requested follow-up instead of claiming that a click executed a tool.
+
+## Readiness and sizing
+
+`ui/ready` and `ui/notifications/initialized` mark the iframe ready. The injected ResizeObserver normally handles height automatically. A widget may also send:
 
 ```javascript
 window.parent.postMessage({
   jsonrpc: "2.0",
   method: "ui/resize",
-  params: {
-    height: document.body.scrollHeight
-  }
+  params: { height: document.body.scrollHeight }
 }, "*");
 ```
 
----
-
-## 3. Host-to-Client Invocations (Host -> Iframe)
-
-Listen for messages inside the iframe via `window.addEventListener("message", ...)`:
-
-```javascript
-window.addEventListener("message", (event) => {
-  const message = event.data;
-  if (!message || message.jsonrpc !== "2.0") return;
-
-  switch (message.method) {
-    case "ui/initialize":
-      applyTheme(message.params.theme);
-      break;
-    case "ui/notifications/host-context-changed":
-      applyTheme(message.params.theme);
-      break;
-    case "ui/updateState":
-      renderState(message.params.state);
-      break;
-  }
-});
-```
+The host accepts positive finite heights and clamps them to 60–2400px. No `ui/updateState` handler is provided by this adapter.

--- a/src/client/Reader.tsx
+++ b/src/client/Reader.tsx
@@ -8,7 +8,7 @@ import { ToolActivity, ToolMedia } from './ToolActivity.js';
 import { preparingLabel, readerFlow } from './tool-activity.js';
 import { Disclosure, ProcessFragment, RetiringContent, StatusText, useMotionAllowed, usePinnedSelection, useReadingScroll } from './motion.js';
 import { StreamMotionContext } from './streaming.js';
-import { assistantSegments, boundaryOf, groupNodes, hasProcessContent, hasVisibleBody, isEarlierNarration, processChoiceKey, processExpanded, terminalLabel } from './projection.js';
+import { assistantSegments, boundaryOf, forkAnchorSeq, groupNodes, hasProcessContent, hasVisibleBody, isEarlierNarration, processChoiceKey, processExpanded, terminalLabel } from './projection.js';
 import { basename, createProducedFileMentions, dirname, getTurnDeliverables } from './deliverables.js';
 import { ContextInjectionRow } from './native/ContextInjectionRow.js';
 import { TimelineRail } from './TimelineRail.js';
@@ -84,7 +84,13 @@ const AssistantNode = memo(function AssistantNode({ useChat, nodeKey, boundary, 
         <Blocks {...render} blocks={part.blocks} streaming={data.status === 'running'} holdFormatting={pinned} startedAt={data.time} interrupted={data.status === 'interrupted'} liveText />
         {index === parts.length - 1 && data.status === 'interrupted' && <span className={css.stopped}>已停止</span>}
         {index === parts.length - 1 && !earlier && data.status !== 'running' && boundary.status === 'closed' && (
-          <CopyAnswer blocks={body} onFork={render.forkAt ? () => render.forkAt!(data.seq) : undefined} metrics={render.metrics} />
+          <CopyAnswer blocks={body} onFork={(() => {
+            // The fork anchor must be the durable closing message seq (same as
+            // the official turn-tail branch). AssistantChatData carries no seq
+            // of its own; passing it would fork the whole session instead.
+            const anchor = forkAnchorSeq([data.finalNode, { seq: render.forkSeq }]);
+            return render.forkAt && anchor !== undefined ? () => render.forkAt!(anchor) : undefined;
+          })()} metrics={render.metrics} />
         )}
       </article>
     </RetiringContent>)}</>;
@@ -452,6 +458,7 @@ const TurnGroup = memo(function TurnGroup({ group, motion, pinnedKeys, selectedP
     tokensPerSecond: tailData?.tokensPerSecond,
     ttftMs: tailData?.ttftMs,
   }), [tailData, runMs]);
+  const forkSeq = forkAnchorSeq([tailData?.closing?.finalNode]);
   const shared = {
     useChat: props.useChat,
     renderSlotChain: props.renderSlotChain,
@@ -460,6 +467,7 @@ const TurnGroup = memo(function TurnGroup({ group, motion, pinnedKeys, selectedP
     openFile: props.openFile,
     revealFile: props.revealFile,
     forkAt: props.forkAt,
+    forkSeq,
     fileMentions,
     metrics,
   };

--- a/src/client/Reader.tsx
+++ b/src/client/Reader.tsx
@@ -1,3 +1,4 @@
+import type {} from '@deepseek-ai/dsh-session-turn-outline/types';
 import { Fragment, memo, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode, RefObject } from 'react';
 import type { ChatConversationViewNode, ChatNode, ChatNodeKind } from '@deepseek-ai/dsh-client-ui-chat/client';
@@ -216,7 +217,7 @@ const MainNode = memo(function MainNode({ useChat, nodeKey, boundary, pinned, pr
     </div>;
     return node.data.compaction ? <CompactionDivider data={node.data.compaction} /> : null;
   }
-  if (node.kind === 'compaction') return <CompactionDivider data={node.data} />;
+  if (isNode(node, 'compaction')) return <CompactionDivider data={node.data} />;
   if (node.kind === 'context' || node.kind === 'turn-tail' || node.kind === 'system-prompt' || node.kind === 'turn-process') return null;
   return <div className={css.unknown} data-reader-anchor>
     <p>此记录类型暂未接入阅读页：{node.kind}</p>
@@ -447,7 +448,7 @@ const TurnGroup = memo(function TurnGroup({ group, motion, pinnedKeys, selectedP
   const tailData = useMemo(() => {
     for (const key of group.keys) {
       const n = nodes.get(key);
-      if (n?.kind === 'turn-tail') return n.data;
+      if (n && isNode(n, 'turn-tail')) return n.data;
     }
     return undefined;
   }, [group.keys, nodes]);
@@ -527,7 +528,7 @@ export function Reader(props: ReaderProps) {
   const turnsWithDeliverables = useMemo(() => {
     const set = new Set<number>();
     for (const [turnNum, loc] of timeline.turns) {
-      const deliv = loc.data?.get('deliverables') as { produced?: unknown[] } | undefined;
+      const deliv = (loc.data as { get(key: string): unknown } | undefined)?.get('deliverables') as { produced?: unknown[] } | undefined;
       if (Array.isArray(deliv?.produced) && deliv.produced.length > 0) {
         set.add(turnNum);
       }

--- a/src/client/TurnMetrics.tsx
+++ b/src/client/TurnMetrics.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useRef, useState } from 'react';
-import type { TurnTokenUsage } from '@deepseek-ai/dsh-client-ui-chat/client';
+import type { TurnTailChatData } from '@deepseek-ai/dsh-client-ui-chat/client';
+type TurnTokenUsage = NonNullable<TurnTailChatData['tokenUsage']>;
 import css from './TurnMetrics.module.css';
 
 interface TurnMetricsProps {
@@ -128,7 +129,7 @@ export const TurnMetrics = memo(function TurnMetrics({
                     <span className={css.popBadge}>命中 {cacheHitPercent}%</span>
                   )}
                 </span>
-                <span className={css.popValue}>{usage!.inputTokens?.toLocaleString() ?? 0} tok</span>
+                <span className={css.popValue}>{(usage!.totalTokens - usage!.outputTokens).toLocaleString()} tok</span>
 
                 {typeof usage!.cacheReadTokens === 'number' && usage!.cacheReadTokens > 0 && (
                   <>

--- a/src/client/deliverables.ts
+++ b/src/client/deliverables.ts
@@ -36,7 +36,7 @@ export function getTurnDeliverables(turn: TurnLocation | undefined, flow?: reado
   const seen = new Set<string>();
 
   // 1. Check official deliverables turn data from @deepseek-ai/dsh-client-ui-deliverables
-  const deliverables = turn?.data.get('deliverables') as DeliverablesData | undefined;
+  const deliverables = (turn?.data as { get(key: string): unknown } | undefined)?.get('deliverables') as DeliverablesData | undefined;
   if (deliverables?.produced && Array.isArray(deliverables.produced)) {
     for (const item of deliverables.produced) {
       if (typeof item?.path === 'string' && item.path.trim().length > 0) {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -102,6 +102,12 @@ export function apply(ctx: Context): void {
           }
         },
         forkAt: (seq: number) => {
+          // A missing anchor would silently fork the whole session instead of
+          // the intended turn prefix, so refuse it loudly rather than guessing.
+          if (typeof seq !== 'number' || !Number.isFinite(seq)) {
+            console.warn('[dsh-better-display] fork refused: missing anchor seq');
+            return;
+          }
           try {
             const sessionsApi = ctx.sessions as unknown as {
               fork: (arg: { sessionId: string; atSeq: number; increaseTitle: boolean }) => Promise<string>;

--- a/src/client/projection.ts
+++ b/src/client/projection.ts
@@ -100,3 +100,19 @@ export function terminalLabel(reason: string | null): string | null {
     default: return `本轮结束状态：${reason}。请在原对话中核对完整记录。`;
   }
 }
+
+/**
+ * Extract the first usable fork anchor seq from candidate message nodes.
+ * Only the durable closing message seq cuts the intended turn prefix: an
+ * absent anchor must surface as undefined (never as 0 or NaN), because the
+ * host treats a missing atSeq as a whole-session fork.
+ */
+export function forkAnchorSeq(
+  candidates: ReadonlyArray<{ seq?: unknown } | null | undefined>,
+): number | undefined {
+  for (const candidate of candidates) {
+    const seq = candidate?.seq;
+    if (typeof seq === 'number' && Number.isFinite(seq)) return seq;
+  }
+  return undefined;
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -51,7 +51,7 @@ export type BlockRenderProps = Pick<ReaderProps, 'renderSlotChain' | 'loadImage'
   forkSeq?: number;
   fileMentions?: MarkdownFileMentions;
   metrics?: {
-    usage?: import('@deepseek-ai/dsh-client-ui-chat/client').TurnTokenUsage;
+    usage?: NonNullable<import('@deepseek-ai/dsh-client-ui-chat/client').TurnTailChatData['tokenUsage']>;
     runMs?: number;
     tokensPerSecond?: number;
     ttftMs?: number;

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -47,6 +47,8 @@ export type BlockRenderProps = Pick<ReaderProps, 'renderSlotChain' | 'loadImage'
   openFile?: (path: string) => Promise<void> | void;
   revealFile?: (path: string) => Promise<void> | void;
   forkAt?: (seq: number) => void;
+  /** Durable closing-message seq of this turn (turn-tail closing), used as the fork anchor. */
+  forkSeq?: number;
   fileMentions?: MarkdownFileMentions;
   metrics?: {
     usage?: import('@deepseek-ai/dsh-client-ui-chat/client').TurnTokenUsage;

--- a/src/client/word-timeline.ts
+++ b/src/client/word-timeline.ts
@@ -55,7 +55,7 @@ export class WordTimeline {
     this.source = source;
     this.enabled = enabled;
     this.revision = revision;
-    this.hasLiveText ||= enabled;
+    this.hasLiveText = enabled && this.births.length > 0;
   }
 
   bornAt(offset: number): number | null {
@@ -74,16 +74,23 @@ export class WordTimeline {
     // Atomic inline animation boxes must not turn commas into legal line starts
     // or strand opening quotes at a line end. Keep source-offset identities when
     // punctuation arrives in a later chunk, so the preceding word never replays.
+    // Already received text is one inert leaf, not thousands of React Words.
+    // Only the newly appended suffix needs word identities and birth times.
+    const prefixLength = Math.min(value.length, Math.max(0, this.floor - offset));
+    const prefix: RevealingWord[] = prefixLength > 0
+      ? [{ key: offset, text: value.slice(0, prefixLength), born: null }]
+      : [];
     const parts: { index: number; segment: string }[] = [];
-    for (const part of segmenter.segment(value)) {
+    for (const segment of segmenter.segment(value.slice(prefixLength))) {
+      const part = { index: prefixLength + segment.index, segment: segment.segment };
       const previous = parts.at(-1);
       if (previous?.segment.trim() && (closingPunctuation.test(part.segment) || openingPunctuation.test(previous.segment))) {
         previous.segment += part.segment;
       } else parts.push({ index: part.index, segment: part.segment });
     }
-    return parts.map(part => {
+    return prefix.concat(parts.map(part => {
       const key = offset + part.index;
       return { key, text: part.segment, born: this.bornAt(key) };
-    });
+    }));
   }
 }

--- a/tests/history-word-regression.test.ts
+++ b/tests/history-word-regression.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { WordTimeline } from '../src/client/word-timeline.js';
+
+test('opening a long existing answer does not animate every historical word', () => {
+  const timeline = new WordTimeline();
+  const history = '已经接收的历史文字。'.repeat(20000);
+  timeline.begin(history, true, 0, 100);
+  assert.equal(timeline.hasLiveText, false, 'history must bypass per-word components');
+
+  timeline.begin(history + '新内容', true, 0, 200);
+  assert.equal(timeline.hasLiveText, true);
+  const words = timeline.words(history + '新内容', 0);
+  assert.ok(words.length < 10, `historical prefix expanded into ${words.length} words`);
+  assert.equal(words.map(word => word.text).join(''), history + '新内容');
+});

--- a/tests/projection.test.ts
+++ b/tests/projection.test.ts
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { AssistantBlock, ToolCallBlock, TurnLocation } from '@deepseek-ai/dsh-client-ui-conversation/client';
 import type { AssistantChatData, ChatConversationViewNode } from '@deepseek-ai/dsh-client-ui-chat/client';
-import { assistantSegments, boundaryOf, groupNodes, hasProcessContent, hasVisibleBody, isEarlierNarration, processChoiceKey, processExpanded, terminalLabel, toolFailed } from '../src/client/projection.ts';
+import { assistantSegments, boundaryOf, forkAnchorSeq, groupNodes, hasProcessContent, hasVisibleBody, isEarlierNarration, processChoiceKey, processExpanded, terminalLabel, toolFailed } from '../src/client/projection.ts';
 import type { TurnBoundary } from '../src/client/projection.ts';
 import { activityPhase, activitySummary, inputFields, readerFlow } from '../src/client/tool-activity.ts';
 
@@ -173,4 +173,12 @@ test('a nonzero terminal exit is a failure even when the tool transport is non-e
   assert.equal(activityPhase({ block }), 'failed');
   assert.equal(activityPhase({ block: { ...block, meta: null } as ToolCallBlock }), 'returned');
   assert.equal(activityPhase({}, true), 'interrupted');
+});
+
+test('fork anchor prefers the durable closing seq and never yields a missing anchor', () => {
+  assert.equal(forkAnchorSeq([{ seq: 42 }]), 42);
+  assert.equal(forkAnchorSeq([null, undefined, {}, { seq: '42' as unknown as number }, { seq: 7 }]), 7);
+  assert.equal(forkAnchorSeq([{ seq: NaN }, { seq: Infinity }, { seq: 100.5 }]), 100.5);
+  assert.equal(forkAnchorSeq([]), undefined);
+  assert.equal(forkAnchorSeq([null, {}, { seq: undefined }]), undefined);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "strict": true, "skipLibCheck": true, "declaration": true,
     "declarationMap": true, "sourceMap": true,
     "rootDir": "src", "outDir": "lib/types", "jsx": "react-jsx",
-    "lib": ["ES2024", "DOM", "DOM.Iterable"]
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "types": ["node", "react"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Opening long existing conversations could create per-word animation components for historical text. Keep historical text inert and animate only appended content. Also complete the standalone RC1 dependency linker so a fresh checkout resolves the session controller and turn outline types.

This includes the pending durable fork-anchor fix and latest skill documentation already on the repair branch.

Validation: 63 tests; TypeScript + client build from a fresh isolated directory against DSH 0.1.2-rc.1; cold Reader render with both pending fields absent; original 34-turn conversation loaded through all 18 history pages in the native/current Host acceptance from this repair session. No history was removed. Initial renderer exit cause is not conclusively attributed solely to word expansion.

Addresses #1 and #4. The old alpha.1 release and Windows-specific host restart were not separately tested; the supported verification target is RC1.
